### PR TITLE
Hand records per section

### DIFF
--- a/Aktywator.txt
+++ b/Aktywator.txt
@@ -2,6 +2,13 @@
 - nie działa oddzielne maksowanie każdego sektora
 
 ---------------------
+Aktywator 1.0.6
+26.11.2016 [mkl]
+ * wczytywanie rozkładów jedynie dla istniejących sektorów (i potrzebnych w nich zakresach numeracji)
+ * możliwość wyboru sektorów do wczytywania rozkładów
+TODO: nieciągłe numeracje rozdań
+
+---------------------
 Aktywator 1.0.5
 20.11.2016 [mkl]
  * opcje zbierania licytacji i rozgrywki (BM2)

--- a/Aktywator.txt
+++ b/Aktywator.txt
@@ -2,6 +2,13 @@
 - nie działa oddzielne maksowanie każdego sektora
 
 ---------------------
+Aktywator 1.0.5
+20.11.2016 [mkl]
+ * opcje zbierania licytacji i rozgrywki (BM2)
+ * opcja weryfikacji pierwszego wistu wobec wczytanych rozkładów (BM2, firmware 2.2.1+, BCS 3.2.x+)
+ * wczytywanie rozkładów wraz z analizą w widne (do użycia np. z wykrywaniem burtówek w BCS 3.2.23+)
+
+---------------------
 Aktywator 1.0.4
 12.04.2013
 

--- a/Aktywator/Aktywator.csproj
+++ b/Aktywator/Aktywator.csproj
@@ -61,10 +61,11 @@
     <GenerateManifests>true</GenerateManifests>
   </PropertyGroup>
   <PropertyGroup>
-    <SignManifests>true</SignManifests>
+    <SignManifests>false</SignManifests>
   </PropertyGroup>
+  <PropertyGroup />
   <ItemGroup>
-    <Reference Include="MySql.Data, Version=6.3.6.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL" />
+    <Reference Include="MySql.Data, Version=6.9.7.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />

--- a/Aktywator/Aktywator.csproj
+++ b/Aktywator/Aktywator.csproj
@@ -124,7 +124,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-    <None Include="Aktywator_TemporaryKey.pfx" />
     <None Include="app.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/Aktywator/Bws.cs
+++ b/Aktywator/Bws.cs
@@ -59,12 +59,12 @@ namespace Aktywator
             settings.Add(new Setting("BM2ValidateLeadCard", main.xCheckLeadCard, this));
         }
 
-        public string sectionsForHandRecords()
+        private string getSectionList(string table)
         {
             try
             {
                 string s;
-                data d = sql.select("SELECT DISTINCT `Section` FROM HandRecord ORDER BY 1");
+                data d = sql.select("SELECT DISTINCT `Section` FROM " + table + " ORDER BY 1");
                 d.Read();
                 s = d[0].ToString();
                 while (d.Read())
@@ -77,6 +77,17 @@ namespace Aktywator
             {
                 return null;
             }
+        }
+
+        public string getSections()
+        {
+            return this.getSectionList("RoundData");
+        }
+
+
+        public string sectionsForHandRecords()
+        {
+            return this.getSectionList("HandRecord");
         }
 
         public void runBCS()

--- a/Aktywator/Bws.cs
+++ b/Aktywator/Bws.cs
@@ -404,20 +404,33 @@ namespace Aktywator
             }
         }
 
-        public int lowBoard()
+        private int getBoard(string function, string sector)
         {
-            string s = sql.selectOne("SELECT min(lowBoard) FROM RoundData WHERE lowBoard > 0");
+            sector = sector.Trim();
+            StringBuilder query = new StringBuilder();
+            query.Append("SELECT ");
+            query.Append(function);
+            query.Append(" FROM RoundData WHERE lowBoard > 0");
+            if (sector.Length > 0)
+            {
+                query.Append(" AND `Section` IN(");
+                query.Append(sector);
+                query.Append(")");
+            }
+            string s = sql.selectOne(query.ToString());
             int i;
             if (int.TryParse(s, out i)) return i;
             else return 0;
         }
 
-        public int highBoard()
+        public int lowBoard(string sector = "")
         {
-            string s = sql.selectOne("SELECT max(highBoard) FROM RoundData WHERE highBoard > 0");
-            int i;
-            if (int.TryParse(s, out i)) return i;
-            else return 0;
+            return this.getBoard("MIN(lowBoard)", sector);
+        }
+
+        public int highBoard(string sector = "")
+        {
+            return this.getBoard("MAX(highBoard)", sector);
         }
 
         public int highSection()

--- a/Aktywator/Bws.cs
+++ b/Aktywator/Bws.cs
@@ -27,7 +27,16 @@ namespace Aktywator
             this._filename = filename;
             sql = new Sql(filename);
             this.main = main;
-            main.lWczytywane.Text = this.getBoardRangeText(this.getSections().Split(','));
+            string[] sections = this.getSections().Split(',');
+            main.lWczytywane.Text = this.getBoardRangeText(sections);
+            foreach (string section in sections)
+            {
+                main.cblSections.Items.Add(this.sectorNumberToLetter(Int16.Parse(section)));
+            }
+            for (int i = 0; i < main.cblSections.Items.Count; i++)
+            {
+                main.cblSections.SetItemChecked(i, true);
+            }
         }
 
         private int sectorLetterToNumber(string sector)
@@ -56,6 +65,16 @@ namespace Aktywator
                 sb.Append(")");
             }
             return sb.ToString();
+        }
+
+        public string[] getSelectedSections()
+        {
+            List<string> sections = new List<string>();
+            foreach (string section in main.cblSections.CheckedItems)
+            {
+                sections.Add(this.sectorLetterToNumber(section).ToString());
+            }
+            return sections.ToArray();
         }
 
         public void initSettings()

--- a/Aktywator/Bws.cs
+++ b/Aktywator/Bws.cs
@@ -50,7 +50,7 @@ namespace Aktywator
             return character.ToString();
         }
 
-        private string getBoardRangeText(string[] sectors)
+        public string getBoardRangeText(string[] sectors)
         {
             StringBuilder sb = new StringBuilder();
             sb.Append("Wczytywane rozkłady:");

--- a/Aktywator/Bws.cs
+++ b/Aktywator/Bws.cs
@@ -514,9 +514,10 @@ namespace Aktywator
             }
         }
 
-        public void loadHandRecords(PBN pbn)
+        public int loadHandRecords(PBN pbn)
         {
-            foreach (string section in this.getSections().Split(','))
+            int count = 0;
+            foreach (string section in this.getSelectedSections())
             {
                 this.clearRecords(section);
                 for (int i = this.lowBoard(section.Trim()); i <= this.highBoard(section.Trim()); i++)
@@ -570,8 +571,10 @@ namespace Aktywator
                             ddStr.Append(")");
                             sql.query(ddStr.ToString());
                         }
+                        count++;
                     }
             }
+            return count;
         }
     }
 }

--- a/Aktywator/Bws.cs
+++ b/Aktywator/Bws.cs
@@ -417,13 +417,21 @@ namespace Aktywator
             else return 0;
         }
 
+        public int lowSection()
+        {
+            string s = sql.selectOne("SELECT min(`Section`) FROM `Tables`");
+            int i;
+            if (int.TryParse(s, out i)) return i;
+            else return 0;
+        }
+
         public void loadHandRecords(PBN pbn)
         {
             sql.query("DELETE FROM HandRecord");
             sql.query("DELETE FROM HandEvaluation");
             for (int i = 0; i < pbn.handRecords.Length; i++)
                 if (pbn.handRecords[i] != null)
-                    for (int section = 1; section <= highSection(); section++)
+                    for (int section = lowSection(); section <= highSection(); section++)
                     {
                         HandRecord b = pbn.handRecords[i];
                         StringBuilder str = new StringBuilder(50);

--- a/Aktywator/Bws.cs
+++ b/Aktywator/Bws.cs
@@ -27,7 +27,35 @@ namespace Aktywator
             this._filename = filename;
             sql = new Sql(filename);
             this.main = main;
-            main.lWczytywane.Text += this.lowBoard() + "-" + this.highBoard();
+            main.lWczytywane.Text = this.getBoardRangeText(this.getSections().Split(','));
+        }
+
+        private int sectorLetterToNumber(string sector)
+        {
+            return sector[0] - 'A' + 1;
+        }
+
+        private string sectorNumberToLetter(int sector)
+        {
+            char character = (char)('A' - 1 + sector);
+            return character.ToString();
+        }
+
+        private string getBoardRangeText(string[] sectors)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append("Wczytywane rozkłady:");
+            foreach (string sector in sectors)
+            {
+                sb.Append("\n      ");
+                sb.Append(this.lowBoard(sector));
+                sb.Append("-");
+                sb.Append(this.highBoard(sector));
+                sb.Append(" (sektor ");
+                sb.Append(this.sectorNumberToLetter(Int16.Parse(sector)));
+                sb.Append(")");
+            }
+            return sb.ToString();
         }
 
         public void initSettings()
@@ -453,9 +481,10 @@ namespace Aktywator
         {
             sql.query("DELETE FROM HandRecord");
             sql.query("DELETE FROM HandEvaluation");
-            for (int i = 0; i < pbn.handRecords.Length; i++)
-                if (pbn.handRecords[i] != null)
-                    for (int section = lowSection(); section <= highSection(); section++)
+            foreach (string section in this.getSections().Split(','))
+            {
+                for (int i = this.lowBoard(section.Trim()); i <= this.highBoard(section.Trim()); i++)
+                    if (pbn.handRecords[i] != null)
                     {
                         HandRecord b = pbn.handRecords[i];
                         StringBuilder str = new StringBuilder(50);
@@ -506,6 +535,7 @@ namespace Aktywator
                             sql.query(ddStr.ToString());
                         }
                     }
+            }
         }
     }
 }

--- a/Aktywator/Bws.cs
+++ b/Aktywator/Bws.cs
@@ -496,12 +496,29 @@ namespace Aktywator
             else return 0;
         }
 
+        private void clearRecords(string section)
+        {
+            sql.query("DELETE FROM HandRecord WHERE `Section` = " + section);
+            sql.query("DELETE FROM HandEvaluation WHERE `Section` = " + section);
+        }
+
+        public void clearHandRecords()
+        {
+            string sections = this.sectionsForHandRecords();
+            if (sections != null)
+            {
+                foreach (string section in this.sectionsForHandRecords().Split(','))
+                {
+                    this.clearRecords(section.Trim());
+                }
+            }
+        }
+
         public void loadHandRecords(PBN pbn)
         {
-            sql.query("DELETE FROM HandRecord");
-            sql.query("DELETE FROM HandEvaluation");
             foreach (string section in this.getSections().Split(','))
             {
+                this.clearRecords(section);
                 for (int i = this.lowBoard(section.Trim()); i <= this.highBoard(section.Trim()); i++)
                     if (pbn.handRecords[i] != null)
                     {

--- a/Aktywator/MainForm.Designer.cs
+++ b/Aktywator/MainForm.Designer.cs
@@ -45,6 +45,8 @@
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.xCollectPlay = new System.Windows.Forms.CheckBox();
+            this.xCollectBidding = new System.Windows.Forms.CheckBox();
             this.xCheckLeadCard = new System.Windows.Forms.CheckBox();
             this.xViewHandrecord = new System.Windows.Forms.CheckBox();
             this.xResultsOverview = new System.Windows.Forms.ComboBox();
@@ -106,8 +108,6 @@
             this.bLoadHands = new System.Windows.Forms.Button();
             this.timer = new System.Windows.Forms.Timer(this.components);
             this.openPBN = new System.Windows.Forms.OpenFileDialog();
-            this.xCollectBidding = new System.Windows.Forms.CheckBox();
-            this.xCollectPlay = new System.Windows.Forms.CheckBox();
             this.groupBoxTop.SuspendLayout();
             this.menu.SuspendLayout();
             this.statusStrip1.SuspendLayout();
@@ -282,6 +282,26 @@
             this.tabPage1.Text = "Ustawienia";
             this.tabPage1.UseVisualStyleBackColor = true;
             // 
+            // xCollectPlay
+            // 
+            this.xCollectPlay.AutoSize = true;
+            this.xCollectPlay.Location = new System.Drawing.Point(339, 138);
+            this.xCollectPlay.Name = "xCollectPlay";
+            this.xCollectPlay.Size = new System.Drawing.Size(146, 17);
+            this.xCollectPlay.TabIndex = 31;
+            this.xCollectPlay.Text = "zbieraj przebieg rozgrywki";
+            this.xCollectPlay.UseVisualStyleBackColor = true;
+            // 
+            // xCollectBidding
+            // 
+            this.xCollectBidding.AutoSize = true;
+            this.xCollectBidding.Location = new System.Drawing.Point(339, 115);
+            this.xCollectBidding.Name = "xCollectBidding";
+            this.xCollectBidding.Size = new System.Drawing.Size(97, 17);
+            this.xCollectBidding.TabIndex = 30;
+            this.xCollectBidding.Text = "zbieraj licytację";
+            this.xCollectBidding.UseVisualStyleBackColor = true;
+            // 
             // xCheckLeadCard
             // 
             this.xCheckLeadCard.AutoSize = true;
@@ -291,7 +311,7 @@
             this.xCheckLeadCard.TabIndex = 32;
             this.xCheckLeadCard.Text = "sprawdź kartę wistu z rozkładem";
             this.xCheckLeadCard.UseVisualStyleBackColor = true;
-            //
+            // 
             // xViewHandrecord
             // 
             this.xViewHandrecord.AutoSize = true;
@@ -909,26 +929,6 @@
             // openPBN
             // 
             this.openPBN.Filter = "PBN|*.pbn";
-            // 
-            // xCollectBidding
-            // 
-            this.xCollectBidding.AutoSize = true;
-            this.xCollectBidding.Location = new System.Drawing.Point(339, 115);
-            this.xCollectBidding.Name = "xCollectBidding";
-            this.xCollectBidding.Size = new System.Drawing.Size(97, 17);
-            this.xCollectBidding.TabIndex = 30;
-            this.xCollectBidding.Text = "zbieraj licytację";
-            this.xCollectBidding.UseVisualStyleBackColor = true;
-            // 
-            // xCollectPlay
-            // 
-            this.xCollectPlay.AutoSize = true;
-            this.xCollectPlay.Location = new System.Drawing.Point(339, 138);
-            this.xCollectPlay.Name = "xCollectPlay";
-            this.xCollectPlay.Size = new System.Drawing.Size(146, 17);
-            this.xCollectPlay.TabIndex = 31;
-            this.xCollectPlay.Text = "zbieraj przebieg rozgrywki";
-            this.xCollectPlay.UseVisualStyleBackColor = true;
             // 
             // MainForm
             // 

--- a/Aktywator/MainForm.Designer.cs
+++ b/Aktywator/MainForm.Designer.cs
@@ -868,7 +868,7 @@
             // 
             this.lWczytywane.AutoSize = true;
             this.lWczytywane.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
-            this.lWczytywane.Location = new System.Drawing.Point(192, 99);
+            this.lWczytywane.Location = new System.Drawing.Point(218, 84);
             this.lWczytywane.Name = "lWczytywane";
             this.lWczytywane.Size = new System.Drawing.Size(139, 13);
             this.lWczytywane.TabIndex = 3;

--- a/Aktywator/MainForm.Designer.cs
+++ b/Aktywator/MainForm.Designer.cs
@@ -100,6 +100,7 @@
             this.bTournament = new System.Windows.Forms.Button();
             this.label3 = new System.Windows.Forms.Label();
             this.tabPage3 = new System.Windows.Forms.TabPage();
+            this.cblSections = new System.Windows.Forms.CheckedListBox();
             this.label14 = new System.Windows.Forms.Label();
             this.label13 = new System.Windows.Forms.Label();
             this.lWczytywane = new System.Windows.Forms.Label();
@@ -108,6 +109,8 @@
             this.bLoadHands = new System.Windows.Forms.Button();
             this.timer = new System.Windows.Forms.Timer(this.components);
             this.openPBN = new System.Windows.Forms.OpenFileDialog();
+            this.lRecordSections = new System.Windows.Forms.Label();
+            this.bClearHands = new System.Windows.Forms.Button();
             this.groupBoxTop.SuspendLayout();
             this.menu.SuspendLayout();
             this.statusStrip1.SuspendLayout();
@@ -851,6 +854,9 @@
             // 
             // tabPage3
             // 
+            this.tabPage3.Controls.Add(this.bClearHands);
+            this.tabPage3.Controls.Add(this.lRecordSections);
+            this.tabPage3.Controls.Add(this.cblSections);
             this.tabPage3.Controls.Add(this.label14);
             this.tabPage3.Controls.Add(this.label13);
             this.tabPage3.Controls.Add(this.lWczytywane);
@@ -865,10 +871,22 @@
             this.tabPage3.Text = "Rozkłady";
             this.tabPage3.UseVisualStyleBackColor = true;
             // 
+            // cblSections
+            // 
+            this.cblSections.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.cblSections.CheckOnClick = true;
+            this.cblSections.FormattingEnabled = true;
+            this.cblSections.Location = new System.Drawing.Point(26, 178);
+            this.cblSections.MultiColumn = true;
+            this.cblSections.Name = "cblSections";
+            this.cblSections.Size = new System.Drawing.Size(456, 105);
+            this.cblSections.TabIndex = 6;
+            this.cblSections.SelectedIndexChanged += new System.EventHandler(this.cblSections_SelectedIndexChanged);
+            // 
             // label14
             // 
             this.label14.AutoSize = true;
-            this.label14.Location = new System.Drawing.Point(6, 197);
+            this.label14.Location = new System.Drawing.Point(6, 315);
             this.label14.Name = "label14";
             this.label14.Size = new System.Drawing.Size(247, 13);
             this.label14.TabIndex = 5;
@@ -877,7 +895,7 @@
             // label13
             // 
             this.label13.AutoSize = true;
-            this.label13.Location = new System.Drawing.Point(6, 175);
+            this.label13.Location = new System.Drawing.Point(6, 293);
             this.label13.Name = "label13";
             this.label13.Size = new System.Drawing.Size(476, 13);
             this.label13.TabIndex = 4;
@@ -929,6 +947,25 @@
             // openPBN
             // 
             this.openPBN.Filter = "PBN|*.pbn";
+            // 
+            // lRecordSections
+            // 
+            this.lRecordSections.AutoSize = true;
+            this.lRecordSections.Location = new System.Drawing.Point(23, 150);
+            this.lRecordSections.Name = "lRecordSections";
+            this.lRecordSections.Size = new System.Drawing.Size(46, 13);
+            this.lRecordSections.TabIndex = 7;
+            this.lRecordSections.Text = "Sektory:";
+            // 
+            // bClearHands
+            // 
+            this.bClearHands.Location = new System.Drawing.Point(334, 336);
+            this.bClearHands.Name = "bClearHands";
+            this.bClearHands.Size = new System.Drawing.Size(223, 23);
+            this.bClearHands.TabIndex = 8;
+            this.bClearHands.Text = "Usuń rozkłady dla wszystkich sektorów";
+            this.bClearHands.UseVisualStyleBackColor = true;
+            this.bClearHands.Click += new System.EventHandler(this.bClearHands_Click);
             // 
             // MainForm
             // 
@@ -1047,6 +1084,9 @@
         public System.Windows.Forms.CheckBox xCollectPlay;
         public System.Windows.Forms.CheckBox xCollectBidding;
         public System.Windows.Forms.CheckBox xCheckLeadCard;
+        public System.Windows.Forms.CheckedListBox cblSections;
+        private System.Windows.Forms.Label lRecordSections;
+        private System.Windows.Forms.Button bClearHands;
     }
 }
 

--- a/Aktywator/MainForm.cs
+++ b/Aktywator/MainForm.cs
@@ -287,6 +287,11 @@ namespace Aktywator
             }
         }
 
+        private void cblSections_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            this.lWczytywane.Text = bws.getBoardRangeText(bws.getSelectedSections());
+        }
+
         private void bClearHands_Click(object sender, EventArgs e)
         {
             try

--- a/Aktywator/MainForm.cs
+++ b/Aktywator/MainForm.cs
@@ -11,8 +11,8 @@ namespace Aktywator
 {
     public partial class MainForm : Form
     {
-        public string version = "1.0.4";
-        public string date = "12.04.2013";
+        public string version = "1.0.6";
+        public string date = "26.11.2016";
 
         private Bws bws;
         private Tournament tournament;

--- a/Aktywator/MainForm.cs
+++ b/Aktywator/MainForm.cs
@@ -277,8 +277,8 @@ namespace Aktywator
                 try
                 {
                     PBN pbn = new PBN(openPBN.FileName, bws.lowBoard(), bws.highBoard());
-                    bws.loadHandRecords(pbn);
-                    MessageBox.Show("Wczytanych rozkładów: " + pbn.count, "Rozkłady wczytane!", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    int count = bws.loadHandRecords(pbn);
+                    MessageBox.Show("Wczytanych rozkładów: " + count, "Rozkłady wczytane!", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
                 catch (Exception ex)
                 {

--- a/Aktywator/MainForm.cs
+++ b/Aktywator/MainForm.cs
@@ -287,5 +287,18 @@ namespace Aktywator
             }
         }
 
+        private void bClearHands_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                bws.clearHandRecords();
+                MessageBox.Show("Wyczyszczono rozkłady", "Rozkłady wyczyszczone!", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message, "Błąd czyszczenia rozkładów", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
     }
 }

--- a/Aktywator/Properties/AssemblyInfo.cs
+++ b/Aktywator/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Michał Zimniewicz")]
 [assembly: AssemblyProduct("Aktywator")]
-[assembly: AssemblyCopyright("Copyright © 2011 Michał Zimniewicz")]
+[assembly: AssemblyCopyright("Copyright © 2011-2016 Michał Zimniewicz")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.6.0")]
+[assembly: AssemblyFileVersion("1.0.6.0")]


### PR DESCRIPTION
Na bazie v1.0.5 (#5) dorobiłem usprawnienia obsługi wczytywania rozkładów do BWS.

Zmiany to:

 * trochę refaktoryzacji metod zwracających listy sektorów, maksymalne i minimalne numery rozdań, itp.
 * rozkłady wczytywane są tylko dla sektorów, które faktycznie istnieją w BWS (a nie dla wszystkich od lowSection do highSection)
 * dla każdego sektora wczytywane są tylko te rozkłady, które są grane w danym sektorze (ale bez obsługi nieciągłej numeracji, czytane są wszystkie rozkłady od lowBoard do highBoard, ale dla wartości każdego sektora)
 * rozbudowałem interfejs zakładki "Rozkłady", umożliwiając wczytanie różnych rozkładów do różnych sektorów
 * oraz wyczyszczenie wszystkich rozkładów z BWSa
 * informacyjnie - komunikat o wczytaniu rozkładów zwraca liczbę rekordów zapisanych do BWS, a nie liczbę różnych rozdań wczytanych z PBN

Zbudowana paczka z binarką dostępna w tagu: https://github.com/emkael/aktywator/releases/tag/v1.0.6
