### PR TITLE
Identyfikacja pliku PBN przy wczytywaniu rozkładów

### DIFF
--- a/Aktywator.txt
+++ b/Aktywator.txt
@@ -2,6 +2,11 @@
 - nie działa oddzielne maksowanie każdego sektora
 
 ---------------------
+Aktywator 1.0.7
+13.03.2017 [mkl]
+ * identyfikacja pliku PBN (po nazwie Event oraz pikach pierwszej ręki) przy wczytywaniu rozkładów do BWSa
+
+---------------------
 Aktywator 1.0.6
 26.11.2016 [mkl]
  * wczytywanie rozkładów jedynie dla istniejących sektorów (i potrzebnych w nich zakresach numeracji)

--- a/Aktywator/MainForm.cs
+++ b/Aktywator/MainForm.cs
@@ -277,8 +277,30 @@ namespace Aktywator
                 try
                 {
                     PBN pbn = new PBN(openPBN.FileName, bws.lowBoard(), bws.highBoard());
-                    int count = bws.loadHandRecords(pbn);
-                    MessageBox.Show("Wczytanych rozkładów: " + count, "Rozkłady wczytane!", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    StringBuilder confirmMsg = new StringBuilder();
+                    confirmMsg.Append("Wczytane zostaną rozkłady z następującego pliku:\n" + "");
+                    if (pbn.title != null && !pbn.title.Equals(""))
+                    {
+                        confirmMsg.Append("\nNagłówek pliku: " + pbn.title);
+                    }
+                    confirmMsg.Append("\nPierwszy rozkład: ");
+                    for (int i = 0; i < pbn.handRecords[bws.lowBoard()].north.Length; i++)
+                    {
+                        if ("".Equals(pbn.handRecords[bws.lowBoard()].north[i]))
+                        {
+                            confirmMsg.Append("renons, ");
+                        }
+                        else
+                        {
+                            confirmMsg.Append(pbn.handRecords[bws.lowBoard()].north[i]);
+                            break;
+                        }
+                    }
+                    if (MessageBox.Show(confirmMsg.ToString(), "Potwierdź rozkłady", MessageBoxButtons.YesNo) == DialogResult.Yes)
+                    {
+                        int count = bws.loadHandRecords(pbn);
+                        MessageBox.Show("Wczytanych rozkładów: " + count, "Rozkłady wczytane!", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/Aktywator/PBN.cs
+++ b/Aktywator/PBN.cs
@@ -17,6 +17,11 @@ namespace Aktywator
         {
             get { return _count; }
         }
+        private String _title;
+        public String title
+        {
+            get { return _title; }
+        }
 
         public PBN(string filename, int lowBoard, int highBoard)
         {
@@ -37,6 +42,10 @@ namespace Aktywator
                     this.ddTables[boardNo] = new DDTable(board);
                     this._count++;
                 }
+            }
+            if (pbn.Boards.Count > 0 && pbn.Boards[0].HasField("Event"))
+            {
+                this._title = pbn.Boards[0].GetField("Event");
             }
         }
 


### PR DESCRIPTION
Poniższa zmiana pozwala użytkownikowi na pobieżną kontrolę, jakie rozkłady wczytywane są do BWSa.

Podczas wczytywania rozkładów prezentowana jest prośba o potwierdzenie, wraz z:
 * zawartością pola `Event` PBNa (jeśli jest niepuste)
 * kolorem pikowym pierwszej ręki N z wczytywanego zestawu (ew. "renons, [kolor kierowy]" i tak dalej)
