### PR TITLE
Wersja 1.0.7

### DIFF
--- a/Aktywator/Aktywator.csproj
+++ b/Aktywator/Aktywator.csproj
@@ -65,7 +65,9 @@
   </PropertyGroup>
   <PropertyGroup />
   <ItemGroup>
-    <Reference Include="MySql.Data, Version=6.9.7.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL" />
+    <Reference Include="MySql.Data, Version=6.9.7.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />

--- a/Aktywator/MainForm.cs
+++ b/Aktywator/MainForm.cs
@@ -11,8 +11,8 @@ namespace Aktywator
 {
     public partial class MainForm : Form
     {
-        public string version = "1.0.6";
-        public string date = "26.11.2016";
+        public string version = "1.0.7";
+        public string date = "28.06.2017";
 
         private Bws bws;
         private Tournament tournament;


### PR DESCRIPTION
Wygląda na to, że uporałem się z opisywanym w #5 problemem DLLki.
Jak już udało mi się go odtworzyć, to poszło z górki.
Wystarczyło wymusić kopiowanie assembly do katalogu wynikowego podczas budowania binarki i użycie tej DLLki zamiast tej z instalatora Oracle.

Wypuściłem tag z wersji 1.0.7, więc zawierającej też "ostatnio" scalane zmiany (identyfikację PBNów podczas wczytywania rozkładów).

Paczka z binarką dostępna: https://github.com/emkael/aktywator/releases/tag/v1.0.7