### PR TITLE
Version requirements

### DIFF
--- a/Aktywator.txt
+++ b/Aktywator.txt
@@ -2,6 +2,11 @@
 - nie działa oddzielne maksowanie każdego sektora
 
 ---------------------
+Aktywator 1.0.8
+27.07.2017 [mkl]
+ * kontrola sugerowanych minimalnych wersji oprogramowania BCS wymaganych do działania poszczególnych opcji
+
+---------------------
 Aktywator 1.0.7
 13.03.2017 [mkl]
  * identyfikacja pliku PBN (po nazwie Event oraz pikach pierwszej ręki) przy wczytywaniu rozkładów do BWSa

--- a/Aktywator/Bws.cs
+++ b/Aktywator/Bws.cs
@@ -78,7 +78,7 @@ namespace Aktywator
             return sections.ToArray();
         }
 
-        public void initSettings()
+        public List<Setting> initSettings()
         {
             settings = new List<Setting>();
             settings.Add(new Setting("ShowResults", main.xShowResults, this, new Version(2, 0, 0), new Version(1, 3, 1)));
@@ -105,6 +105,7 @@ namespace Aktywator
             settings.Add(new Setting("BM2RecordBidding", main.xCollectBidding, this, new Version(2, 0, 0), new Version(1, 3, 1)));
             settings.Add(new Setting("BM2RecordPlay", main.xCollectPlay, this, new Version(2, 0, 0), new Version(1, 3, 1)));
             settings.Add(new Setting("BM2ValidateLeadCard", main.xCheckLeadCard, this, new Version(3, 2, 1), new Version(2, 2, 1)));
+            return settings;
         }
 
         private string getSectionList(string table)

--- a/Aktywator/Bws.cs
+++ b/Aktywator/Bws.cs
@@ -21,6 +21,7 @@ namespace Aktywator
         public List<Setting> settings;
         private MainForm main;
         public bool settingsChanged = false;
+        private static string applicationPath = Common.ProgramFilesx86() + "\\Bridgemate Pro\\";
 
         public Bws(string filename, MainForm main)
         {
@@ -137,9 +138,15 @@ namespace Aktywator
             return this.getSectionList("HandRecord");
         }
 
+
+        internal static void setAppLocation(string appPath)
+        {
+            applicationPath = appPath;
+        }
+
         public void runBCS()
         {
-            string app = Common.ProgramFilesx86() + "\\Bridgemate Pro\\BMPro.exe";
+            string app = applicationPath + "BMPro.exe";
             string param = "";
             param += " /f[" + filename + " ]";
             param += " /s";

--- a/Aktywator/Bws.cs
+++ b/Aktywator/Bws.cs
@@ -81,30 +81,30 @@ namespace Aktywator
         public void initSettings()
         {
             settings = new List<Setting>();
-            settings.Add(new Setting("ShowResults", main.xShowResults, this));
-            settings.Add(new Setting("RepeatResults", main.xRepeatResults, this));
-            settings.Add(new Setting("ShowPercentage", main.xShowPercentage, this));
-            //settings.Add(new Setting("GroupSections", main.xGroupSections, this));
-            settings.Add(new Setting("ShowPairNumbers", main.xShowPairNumbers, this));
-            settings.Add(new Setting("IntermediateResults", main.xIntermediateResults, this));
-            settings.Add(new Setting("ShowContract", main.xShowContract, this));
-            settings.Add(new Setting("LeadCard", main.xLeadCard, this));
-            settings.Add(new Setting("MemberNumbers", main.xMemberNumbers, this));
-            settings.Add(new Setting("MemberNumbersNoBlankEntry", main.xMemberNumbersNoBlankEntry, this));
-            settings.Add(new Setting("BoardOrderVerification", main.xBoardOrderVerification, this));
-            settings.Add(new Setting("AutoShutDownBPC", main.xAutoShutDownBPC, this));
-            settings.Add(new Setting("BM2ConfirmNP", main.xConfirmNP, this));
-            settings.Add(new Setting("BM2RemainingBoards", main.xRemainingBoards, this));
-            settings.Add(new Setting("BM2NextSeatings", main.xNextSeatings, this));
-            settings.Add(new Setting("BM2ScoreRecap", main.xScoreRecap, this));
-            settings.Add(new Setting("BM2AutoShowScoreRecap", main.xAutoShowScoreRecap, this));
-            settings.Add(new Setting("BM2ScoreCorrection", main.xScoreCorrection, this));
-            settings.Add(new Setting("BM2AutoBoardNumber", main.xAutoBoardNumber, this));
-            settings.Add(new Setting("BM2ResetFunctionKey", main.xResetFunctionKey, this));
-            settings.Add(new Setting("BM2ViewHandrecord", main.xViewHandrecord, this));
-            settings.Add(new Setting("BM2RecordBidding", main.xCollectBidding, this));
-            settings.Add(new Setting("BM2RecordPlay", main.xCollectPlay, this));
-            settings.Add(new Setting("BM2ValidateLeadCard", main.xCheckLeadCard, this));
+            settings.Add(new Setting("ShowResults", main.xShowResults, this, new Version(2, 0, 0), new Version(1, 3, 1)));
+            settings.Add(new Setting("RepeatResults", main.xRepeatResults, this, null, null));
+            settings.Add(new Setting("ShowPercentage", main.xShowPercentage, this, null, null));
+            //settings.Add(new Setting("GroupSections", main.xGroupSections, this, null, null));
+            settings.Add(new Setting("ShowPairNumbers", main.xShowPairNumbers, this, null, null));
+            settings.Add(new Setting("IntermediateResults", main.xIntermediateResults, this, null, new Version(1, 4, 1)));
+            settings.Add(new Setting("ShowContract", main.xShowContract, this, null, null));
+            settings.Add(new Setting("LeadCard", main.xLeadCard, this, null, null));
+            settings.Add(new Setting("MemberNumbers", main.xMemberNumbers, this, null, null));
+            settings.Add(new Setting("MemberNumbersNoBlankEntry", main.xMemberNumbersNoBlankEntry, this, null, null));
+            settings.Add(new Setting("BoardOrderVerification", main.xBoardOrderVerification, this, null, null));
+            settings.Add(new Setting("AutoShutDownBPC", main.xAutoShutDownBPC, this, new Version(1, 7, 15), null));
+            settings.Add(new Setting("BM2ConfirmNP", main.xConfirmNP, this, new Version(2, 0, 0), new Version(1, 0, 1)));
+            settings.Add(new Setting("BM2RemainingBoards", main.xRemainingBoards, this, new Version(2, 0, 0), new Version(1, 0, 1)));
+            settings.Add(new Setting("BM2NextSeatings", main.xNextSeatings, this, new Version(2, 0, 0), new Version(1, 0, 1)));
+            settings.Add(new Setting("BM2ScoreRecap", main.xScoreRecap, this, new Version(2, 0, 0), new Version(1, 0, 1)));
+            settings.Add(new Setting("BM2AutoShowScoreRecap", main.xAutoShowScoreRecap, this, new Version(2, 5, 1), new Version(1, 0, 1)));
+            settings.Add(new Setting("BM2ScoreCorrection", main.xScoreCorrection, this, new Version(2, 0, 0), new Version(1, 0, 1)));
+            settings.Add(new Setting("BM2AutoBoardNumber", main.xAutoBoardNumber, this, new Version(2, 0, 0), new Version(2, 0, 1)));
+            settings.Add(new Setting("BM2ResetFunctionKey", main.xResetFunctionKey, this, new Version(2, 0, 0), new Version(1, 0, 1)));
+            settings.Add(new Setting("BM2ViewHandrecord", main.xViewHandrecord, this, new Version(2, 6, 1), new Version(1, 6, 1)));
+            settings.Add(new Setting("BM2RecordBidding", main.xCollectBidding, this, new Version(2, 0, 0), new Version(1, 3, 1)));
+            settings.Add(new Setting("BM2RecordPlay", main.xCollectPlay, this, new Version(2, 0, 0), new Version(1, 3, 1)));
+            settings.Add(new Setting("BM2ValidateLeadCard", main.xCheckLeadCard, this, new Version(3, 2, 1), new Version(2, 2, 1)));
         }
 
         private string getSectionList(string table)

--- a/Aktywator/MainForm.Designer.cs
+++ b/Aktywator/MainForm.Designer.cs
@@ -100,6 +100,8 @@
             this.bTournament = new System.Windows.Forms.Button();
             this.label3 = new System.Windows.Forms.Label();
             this.tabPage3 = new System.Windows.Forms.TabPage();
+            this.bClearHands = new System.Windows.Forms.Button();
+            this.lRecordSections = new System.Windows.Forms.Label();
             this.cblSections = new System.Windows.Forms.CheckedListBox();
             this.label14 = new System.Windows.Forms.Label();
             this.label13 = new System.Windows.Forms.Label();
@@ -109,8 +111,12 @@
             this.bLoadHands = new System.Windows.Forms.Button();
             this.timer = new System.Windows.Forms.Timer(this.components);
             this.openPBN = new System.Windows.Forms.OpenFileDialog();
-            this.lRecordSections = new System.Windows.Forms.Label();
-            this.bClearHands = new System.Windows.Forms.Button();
+            this.label15 = new System.Windows.Forms.Label();
+            this.label16 = new System.Windows.Forms.Label();
+            this.label17 = new System.Windows.Forms.Label();
+            this.lRequiredVersion = new System.Windows.Forms.Label();
+            this.lDetectedVersion = new System.Windows.Forms.Label();
+            this.lRequiredFirmware = new System.Windows.Forms.Label();
             this.groupBoxTop.SuspendLayout();
             this.menu.SuspendLayout();
             this.statusStrip1.SuspendLayout();
@@ -196,7 +202,7 @@
             this.status1,
             this.status2,
             this.status3});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 480);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 489);
             this.statusStrip1.Name = "statusStrip1";
             this.statusStrip1.Size = new System.Drawing.Size(577, 22);
             this.statusStrip1.TabIndex = 2;
@@ -228,7 +234,7 @@
             this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.groupBox1.Location = new System.Drawing.Point(0, 70);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(577, 410);
+            this.groupBox1.Size = new System.Drawing.Size(577, 419);
             this.groupBox1.TabIndex = 1;
             this.groupBox1.TabStop = false;
             // 
@@ -241,11 +247,17 @@
             this.tabControl1.Location = new System.Drawing.Point(3, 16);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(571, 391);
+            this.tabControl1.Size = new System.Drawing.Size(571, 400);
             this.tabControl1.TabIndex = 0;
             // 
             // tabPage1
             // 
+            this.tabPage1.Controls.Add(this.lRequiredFirmware);
+            this.tabPage1.Controls.Add(this.lDetectedVersion);
+            this.tabPage1.Controls.Add(this.lRequiredVersion);
+            this.tabPage1.Controls.Add(this.label17);
+            this.tabPage1.Controls.Add(this.label16);
+            this.tabPage1.Controls.Add(this.label15);
             this.tabPage1.Controls.Add(this.xCollectPlay);
             this.tabPage1.Controls.Add(this.xCollectBidding);
             this.tabPage1.Controls.Add(this.xCheckLeadCard);
@@ -280,7 +292,7 @@
             this.tabPage1.Location = new System.Drawing.Point(4, 22);
             this.tabPage1.Name = "tabPage1";
             this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage1.Size = new System.Drawing.Size(563, 365);
+            this.tabPage1.Size = new System.Drawing.Size(563, 374);
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "Ustawienia";
             this.tabPage1.UseVisualStyleBackColor = true;
@@ -357,7 +369,7 @@
             // bSave
             // 
             this.bSave.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
-            this.bSave.Location = new System.Drawing.Point(219, 336);
+            this.bSave.Location = new System.Drawing.Point(185, 336);
             this.bSave.Name = "bSave";
             this.bSave.Size = new System.Drawing.Size(126, 23);
             this.bSave.TabIndex = 25;
@@ -639,7 +651,7 @@
             this.tabPage2.Location = new System.Drawing.Point(4, 22);
             this.tabPage2.Name = "tabPage2";
             this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage2.Size = new System.Drawing.Size(563, 365);
+            this.tabPage2.Size = new System.Drawing.Size(563, 374);
             this.tabPage2.TabIndex = 1;
             this.tabPage2.Text = "Nazwiska";
             this.tabPage2.UseVisualStyleBackColor = true;
@@ -866,10 +878,29 @@
             this.tabPage3.Location = new System.Drawing.Point(4, 22);
             this.tabPage3.Name = "tabPage3";
             this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage3.Size = new System.Drawing.Size(563, 365);
+            this.tabPage3.Size = new System.Drawing.Size(563, 374);
             this.tabPage3.TabIndex = 2;
             this.tabPage3.Text = "Rozkłady";
             this.tabPage3.UseVisualStyleBackColor = true;
+            // 
+            // bClearHands
+            // 
+            this.bClearHands.Location = new System.Drawing.Point(334, 336);
+            this.bClearHands.Name = "bClearHands";
+            this.bClearHands.Size = new System.Drawing.Size(223, 23);
+            this.bClearHands.TabIndex = 8;
+            this.bClearHands.Text = "Usuń rozkłady dla wszystkich sektorów";
+            this.bClearHands.UseVisualStyleBackColor = true;
+            this.bClearHands.Click += new System.EventHandler(this.bClearHands_Click);
+            // 
+            // lRecordSections
+            // 
+            this.lRecordSections.AutoSize = true;
+            this.lRecordSections.Location = new System.Drawing.Point(23, 150);
+            this.lRecordSections.Name = "lRecordSections";
+            this.lRecordSections.Size = new System.Drawing.Size(46, 13);
+            this.lRecordSections.TabIndex = 7;
+            this.lRecordSections.Text = "Sektory:";
             // 
             // cblSections
             // 
@@ -948,30 +979,65 @@
             // 
             this.openPBN.Filter = "PBN|*.pbn";
             // 
-            // lRecordSections
+            // label15
             // 
-            this.lRecordSections.AutoSize = true;
-            this.lRecordSections.Location = new System.Drawing.Point(23, 150);
-            this.lRecordSections.Name = "lRecordSections";
-            this.lRecordSections.Size = new System.Drawing.Size(46, 13);
-            this.lRecordSections.TabIndex = 7;
-            this.lRecordSections.Text = "Sektory:";
+            this.label15.AutoSize = true;
+            this.label15.Location = new System.Drawing.Point(315, 319);
+            this.label15.Name = "label15";
+            this.label15.Size = new System.Drawing.Size(121, 13);
+            this.label15.TabIndex = 33;
+            this.label15.Text = "Wymagana wersja BCS:";
             // 
-            // bClearHands
+            // label16
             // 
-            this.bClearHands.Location = new System.Drawing.Point(334, 336);
-            this.bClearHands.Name = "bClearHands";
-            this.bClearHands.Size = new System.Drawing.Size(223, 23);
-            this.bClearHands.TabIndex = 8;
-            this.bClearHands.Text = "Usuń rozkłady dla wszystkich sektorów";
-            this.bClearHands.UseVisualStyleBackColor = true;
-            this.bClearHands.Click += new System.EventHandler(this.bClearHands_Click);
+            this.label16.AutoSize = true;
+            this.label16.Location = new System.Drawing.Point(330, 336);
+            this.label16.Name = "label16";
+            this.label16.Size = new System.Drawing.Size(106, 13);
+            this.label16.TabIndex = 34;
+            this.label16.Text = "Wykryta wersja BCS:";
+            // 
+            // label17
+            // 
+            this.label17.AutoSize = true;
+            this.label17.Location = new System.Drawing.Point(330, 352);
+            this.label17.Name = "label17";
+            this.label17.Size = new System.Drawing.Size(105, 13);
+            this.label17.TabIndex = 35;
+            this.label17.Text = "Wymagany firmware:";
+            // 
+            // lRequiredVersion
+            // 
+            this.lRequiredVersion.AutoSize = true;
+            this.lRequiredVersion.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
+            this.lRequiredVersion.Location = new System.Drawing.Point(448, 319);
+            this.lRequiredVersion.Name = "lRequiredVersion";
+            this.lRequiredVersion.Size = new System.Drawing.Size(0, 13);
+            this.lRequiredVersion.TabIndex = 36;
+            // 
+            // lDetectedVersion
+            // 
+            this.lDetectedVersion.AutoSize = true;
+            this.lDetectedVersion.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
+            this.lDetectedVersion.Location = new System.Drawing.Point(448, 336);
+            this.lDetectedVersion.Name = "lDetectedVersion";
+            this.lDetectedVersion.Size = new System.Drawing.Size(0, 13);
+            this.lDetectedVersion.TabIndex = 37;
+            // 
+            // lRequiredFirmware
+            // 
+            this.lRequiredFirmware.AutoSize = true;
+            this.lRequiredFirmware.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
+            this.lRequiredFirmware.Location = new System.Drawing.Point(448, 352);
+            this.lRequiredFirmware.Name = "lRequiredFirmware";
+            this.lRequiredFirmware.Size = new System.Drawing.Size(0, 13);
+            this.lRequiredFirmware.TabIndex = 38;
             // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(577, 502);
+            this.ClientSize = new System.Drawing.Size(577, 511);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.groupBoxTop);
@@ -1087,6 +1153,12 @@
         public System.Windows.Forms.CheckedListBox cblSections;
         private System.Windows.Forms.Label lRecordSections;
         private System.Windows.Forms.Button bClearHands;
+        private System.Windows.Forms.Label label17;
+        private System.Windows.Forms.Label label16;
+        private System.Windows.Forms.Label label15;
+        private System.Windows.Forms.Label lRequiredFirmware;
+        private System.Windows.Forms.Label lDetectedVersion;
+        private System.Windows.Forms.Label lRequiredVersion;
     }
 }
 

--- a/Aktywator/MainForm.cs
+++ b/Aktywator/MainForm.cs
@@ -99,6 +99,12 @@ namespace Aktywator
                                     && !productName.Equals("Bridgemate Pro Control", StringComparison.OrdinalIgnoreCase))
                                     continue;
 
+                                string appPath = Convert.ToString(appKey.GetValue("InstallLocation"));
+                                if (appPath != null)
+                                {
+                                    Bws.setAppLocation(appPath);
+                                }
+
                                 string version = Convert.ToString(appKey.GetValue("DisplayVersion"));
                                 return version;
                             }

--- a/Aktywator/MainForm.cs
+++ b/Aktywator/MainForm.cs
@@ -21,6 +21,9 @@ namespace Aktywator
 
         private Version BCSVersion;
 
+        public static Version requiredBCSVersion;
+        public static Version requiredFWVersion;
+
         public MainForm()
         {
             InitializeComponent();
@@ -69,8 +72,54 @@ namespace Aktywator
             // cloning Setting List returned from Bws, because we're going to extend it for version tracking purposes
             this.bwsSettings = new List<Setting>(bws.initSettings());
             this.bwsSettings.Add(new Setting("BM2ShowPlayerNames", this.xShowPlayerNames, bws, new Version(2, 0, 0), new Version(1, 3, 1)));
+            bindSettingChanges();
             bws.loadSettings();
             this.WindowState = FormWindowState.Normal;
+        }
+
+        private void bindSettingChanges()
+        {
+            foreach (Setting s in this.bwsSettings)
+            {
+                s.field.CheckedChanged += new EventHandler(setting_field_CheckedChanged);
+            }
+        }
+
+        void setting_field_CheckedChanged(object sender, EventArgs e)
+        {
+            requiredBCSVersion = null;
+            requiredFWVersion = null;
+            foreach (Setting s in this.bwsSettings)
+            {
+                if (s.field.Checked)
+                {
+                    if (requiredBCSVersion == null || requiredBCSVersion < s.bcsV)
+                    {
+                        requiredBCSVersion = s.bcsV;
+                    }
+                    if (requiredFWVersion == null || requiredFWVersion < s.fwV)
+                    {
+                        requiredFWVersion = s.fwV;
+                    }
+                }
+            }
+            lRequiredVersion.Text = (requiredBCSVersion != null) ? requiredBCSVersion.ToString() : "--";
+            lRequiredFirmware.Text = (requiredFWVersion != null) ? requiredFWVersion.ToString() : "--";
+            if (BCSVersion != null)
+            {
+                if (requiredBCSVersion > BCSVersion)
+                {
+                    lDetectedVersion.ForeColor = Color.Red;
+                }
+                else
+                {
+                    lDetectedVersion.ForeColor = Color.Green;
+                }
+            }
+            else
+            {
+                lDetectedVersion.ForeColor = Color.Black;
+            }
         }
 
         private string detectBCSVersion()

--- a/Aktywator/MainForm.cs
+++ b/Aktywator/MainForm.cs
@@ -82,6 +82,24 @@ namespace Aktywator
             foreach (Setting s in this.bwsSettings)
             {
                 s.field.CheckedChanged += new EventHandler(setting_field_CheckedChanged);
+                StringBuilder tBuilder = new StringBuilder();
+                if (s.bcsV != null)
+                {
+                    tBuilder.Append("BCS >= ");
+                    tBuilder.Append(s.bcsV);
+                    tBuilder.Append(", ");
+                }
+                if (s.fwV != null)
+                {
+                    tBuilder.Append("firmware >= ");
+                    tBuilder.Append(s.fwV);
+                }
+                String title = tBuilder.ToString().Trim().Trim(',');
+                if (!("".Equals(title)))
+                {
+                    ToolTip tip = new ToolTip();
+                    tip.SetToolTip(s.field, title);
+                }
             }
         }
 

--- a/Aktywator/MainForm.cs
+++ b/Aktywator/MainForm.cs
@@ -16,6 +16,7 @@ namespace Aktywator
         public string date = "28.06.2017";
 
         private Bws bws;
+        private List<Setting> bwsSettings;
         private Tournament tournament;
 
         private Version BCSVersion;
@@ -65,7 +66,9 @@ namespace Aktywator
                     bws.convert();
 
             labelFilename.Text = filename;
-            bws.initSettings();
+            // cloning Setting List returned from Bws, because we're going to extend it for version tracking purposes
+            this.bwsSettings = new List<Setting>(bws.initSettings());
+            this.bwsSettings.Add(new Setting("BM2ShowPlayerNames", this.xShowPlayerNames, bws, new Version(2, 0, 0), new Version(1, 3, 1)));
             bws.loadSettings();
             this.WindowState = FormWindowState.Normal;
         }

--- a/Aktywator/MainForm.cs
+++ b/Aktywator/MainForm.cs
@@ -12,8 +12,8 @@ namespace Aktywator
 {
     public partial class MainForm : Form
     {
-        public string version = "1.0.7";
-        public string date = "28.06.2017";
+        public string version = "1.0.8";
+        public string date = "27.07.2017";
 
         private Bws bws;
         private List<Setting> bwsSettings;

--- a/Aktywator/Setting.cs
+++ b/Aktywator/Setting.cs
@@ -14,12 +14,16 @@ namespace Aktywator
         public string table;
         public CheckBox field;
         private Bws bws;
+        public Version bcsV;
+        public Version fwV;
 
-        public Setting(string name, CheckBox field, Bws bws)
+        public Setting(string name, CheckBox field, Bws bws, Version bcsVersion, Version firmwareVersion)
         {
             this.name = name;
             this.field = field;
             this.bws = bws;
+            this.bcsV = bcsVersion;
+            this.fwV = firmwareVersion;
         }
 
         public void load()


### PR DESCRIPTION
Zgodnie z #11, gałąź zawiera informacje o numerach wersji BCS, w których dodano obsługę poszczególnych opcji BWS.

W przypadku starszych opcji numeracja firmware serwera, firmware pierniczków i samego BCS trochę się rozjeżdża, zwłaszcza że Aktywator obsługuje również opcje, które były wprowadzone w pierwszej wersji BridgeMate'ów, a aktualizowane dla BM2, więc nie jestem pewien dokładności tych danych.

Jeśli jakieś funkcjonalności korzystają z późniejszych aktualizacji firmware (np. wyświetlanie travellerów), jako numer wersji przyjmowany jest ten najpóźniejszy, dający pełną funkcjonalność.

Do checkboksów dodawane są również tooltipy, które informują o minimalnych wersjach.

Jako efekt uboczny wykrywania numeru wersji zainstalowanego BCS, zaimplementowałem również wykrywanie ścieżki, w jakiej go zainstalowano - i użycie tej ścieżki przy uruchamianiu programu (dotychczas przeszukiwane było tylko 32-bitowe `Program Files`).

Musiałem minimalnie rozszerzyć okno programu w pionie.